### PR TITLE
修正#inspectParametersの変更。-m, -yの同時指定を可能に

### DIFF
--- a/src/EveryRunOption.ts
+++ b/src/EveryRunOption.ts
@@ -22,10 +22,14 @@ export class EveryRunOption {
     }
 
     const entries = parameters.filter(param => param)
-    if (entries.length > 1) {
-      console.log('オプション指定は1つまでです。')
+    if ((!this.#existYearAndMonth() && entries.length > 1) || (this.#existYearAndMonth() && entries.length > 2)) {
+      console.log('Invalid Options.')
       process.exit()
     }
+  }
+
+  #existYearAndMonth (): boolean {
+    return (typeof this.parameters.y === 'number') && (typeof this.parameters.m === 'number')
   }
 
   get parameters (): EveryRunOptions {


### PR DESCRIPTION
## What
- EveryRunOptions#inspectParameters内の条件分岐追加
- 上記条件式用のisYearAndMonthメソッドの追加

## Why
- オプション引数`-m` `-y`を同時に指定できるようにするため
