### PR TITLE
修正#EveryRunDBテストの各テスト後にDBのクローズ処理追加

### DIFF
--- a/test/EveryRunDB.test.ts
+++ b/test/EveryRunDB.test.ts
@@ -15,8 +15,9 @@ describe('EveryRunDBクラス', () => {
     setUpTables(db, { distance, dateString })
   })
 
-  afterAll(() => {
+  afterEach(() => {
     clearDB(db)
+    db.close()
   })
 
   describe('コンストラクタ', () => {


### PR DESCRIPTION
## What
- EveryRunDBテストの`beforeEach`内の処理内容に`db.close()`追加

## Why
- テスト実行時に並列処理が原因で期待した結果が得られていなかったため。